### PR TITLE
Change license to ISC for compatibility with fork.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,21 @@ CSH Haddock
 
 ## License
 
-Original license for
-[Haddock on Heroku](https://github.com/grantovich/haddock-on-heroku) is unknown.
-Everything modified from commit 367c41b7e8ecb9c6b418eeaefc4e215de6a8da7a
-and on is licensed under the MIT License
+[Haddock on Heroku](https://github.com/grantovich/haddock-on-heroku) is Copyright (c) 2016, Alex Grant <https://grantovich.net>.
 
-© 2016, Computer Science House.
+The included 12dicts word list is (c) Alan Beale and has been released into the
+public domain. <http://wordlist.aspell.net/12dicts-readme/>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright © 2016, Computer Science House.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.


### PR DESCRIPTION
Looks like haddock-on-heroku got a [LICENSE](https://github.com/grantovich/haddock-on-heroku/blob/master/LICENSE) file since this readme was written. Since ISC and MIT are functionally equivalent I'm proposing the two projects just match.